### PR TITLE
Starting to replace moment.js with date-fns/date-fns-tz libraries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 .env.development.local
 .env.test.local
 .env.production.local
+.vscode
 
 npm-debug.log*
 yarn-debug.log*

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,8 @@
         "@testing-library/jest-dom": "^5.16.2",
         "@testing-library/react": "^12.1.3",
         "@testing-library/user-event": "^13.5.0",
+        "date-fns": "^2.28.0",
+        "date-fns-tz": "^1.3.3",
         "lodash": "^4.17.21",
         "moment": "^2.29.1",
         "react": "^17.0.2",
@@ -6338,6 +6340,26 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.28.0.tgz",
+      "integrity": "sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw==",
+      "engines": {
+        "node": ">=0.11"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/date-fns"
+      }
+    },
+    "node_modules/date-fns-tz": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-1.3.3.tgz",
+      "integrity": "sha512-Gks46gwbSauBQnV3Oofluj1wTm8J0tM7sbSJ9P+cJq/ZnTCpMohTKmmO5Tn+jQ7dyn0+b8G7cY4O2DZ5P/LXcA==",
+      "peerDependencies": {
+        "date-fns": ">=2.0.0"
       }
     },
     "node_modules/debug": {
@@ -21246,6 +21268,17 @@
         "whatwg-mimetype": "^2.3.0",
         "whatwg-url": "^8.0.0"
       }
+    },
+    "date-fns": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.28.0.tgz",
+      "integrity": "sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw=="
+    },
+    "date-fns-tz": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-1.3.3.tgz",
+      "integrity": "sha512-Gks46gwbSauBQnV3Oofluj1wTm8J0tM7sbSJ9P+cJq/ZnTCpMohTKmmO5Tn+jQ7dyn0+b8G7cY4O2DZ5P/LXcA==",
+      "requires": {}
     },
     "debug": {
       "version": "4.3.3",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "@testing-library/jest-dom": "^5.16.2",
     "@testing-library/react": "^12.1.3",
     "@testing-library/user-event": "^13.5.0",
+    "date-fns": "^2.28.0",
+    "date-fns-tz": "^1.3.3",
     "lodash": "^4.17.21",
     "moment": "^2.29.1",
     "react": "^17.0.2",

--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,5 @@
 import React, { useEffect } from "react";
 import _ from "lodash";
-import moment from "moment";
 import styled from "@emotion/styled";
 import CssBaseline from "@mui/material/CssBaseline";
 import Box from "@mui/material/Box";
@@ -29,6 +28,8 @@ import Events from "./Events";
 import Arbitrage from "./Arbitrage";
 
 import logo from "./img/logo.png";
+import { format,subHours } from "date-fns";
+import { formatInTimeZone } from "date-fns-tz";
 // import "./App.css";
 
 const defaultValues = {
@@ -681,9 +682,11 @@ const defaultEventSettings = {
   timezone: -4, // East = 0 (UTC - 4 (- 0))
 };
 
-const eventsStore = create((set, get) => ({
-  currentDay: moment().utc().subtract(4, "hours").day(),
-  currentTime: moment().utc().subtract(4, "hours").format("HH:mm:ss"),
+
+
+const eventsStore = create((set, get) => ({  
+  currentDay: formatInTimeZone(subHours(new Date(), 4), "UTC", 'i'),
+  currentTime: formatInTimeZone(subHours(new Date(), 4), "UTC", 'HH:mm:ss'),
   eventList: [],
   eventSettings: defaultEventSettings,
   favorites: [],
@@ -715,7 +718,7 @@ const eventsStore = create((set, get) => ({
   },
   setCurrentDay: (currentDay) => {
     set((state) => ({ currentDay }));
-  },
+  },    
   setEventList: (eventList) => {
     set((state) => ({ eventList }));
   },

--- a/src/App.js
+++ b/src/App.js
@@ -718,7 +718,7 @@ const eventsStore = create((set, get) => ({
   },
   setCurrentDay: (currentDay) => {
     set((state) => ({ currentDay }));
-  },    
+  },
   setEventList: (eventList) => {
     set((state) => ({ eventList }));
   },

--- a/src/Events.js
+++ b/src/Events.js
@@ -3,6 +3,8 @@ import _, { times } from "lodash";
 import styled from "@emotion/styled";
 import { css } from "@emotion/react";
 import moment from "moment";
+import { setDay,add } from "date-fns";
+import { format,formatInTimeZone  } from "date-fns-tz";
 import { ThemeProvider } from "@mui/material/styles";
 import Accordion from "@mui/material/Accordion";
 import AccordionDetails from "@mui/material/AccordionDetails";
@@ -45,6 +47,8 @@ export default function Events(props) {
   const nextDay = days[moment(currentDay, "e").add(1, "days").format("e")]; // string "sat"
   const setCurrentTime = useStore((state) => state.setCurrentTime);
   const setCurrentDay = useStore((state) => state.setCurrentDay);
+  const setCurrentDateTime = useStore((state) => state.setCurrentDateTime);
+  const setCurrentDateTimeFNS = useStore((state) => state.setCurrentDateTimeFNS);
   const eventCount = 30;
 
   const parseTimezone = (timezone) => {
@@ -189,11 +193,20 @@ export default function Events(props) {
   // Refreshes clock, temporarily disabled for developing
   useEffect(() => {
     function refreshClock() {
-      setCurrentTime(moment().utc().add(timezone, "hours").format("HH:mm:ss"));
-      setCurrentDay(moment().utc().add(timezone, "hours").format("e"));
+            
+      //old
+      //setCurrentTime(moment().utc().add(timezone, "hours").format("HH:mm:ss"));
+      //new
+      setCurrentTime(formatInTimeZone(add(new Date(), { hours: timezone}), "UTC", 'HH:mm:ss'));      
+
+      //old
+      //setCurrentDay(moment().utc().add(timezone, "hours").format("e"));
+      //new   
+      setCurrentDay(formatInTimeZone(add(new Date(), { hours: timezone}),"UTC",  'i'));
       // Test Time
       // setCurrentTime(moment("6:19", "HH:mm").format("HH:mm:ss"));
       // setCurrentDay(moment("03-25-2022", "MM-DD-YYYY").format("e")); // friday
+
     }
 
     const timerId = setInterval(refreshClock, 1000);
@@ -205,16 +218,14 @@ export default function Events(props) {
   const parsedEvents = parseEvents();
 
   return (
-    <ThemeProvider theme={theme}>
-      <Typography variant="h4" component="h1" align="center">
-        {moment(currentTime, "HH:mm:ss")
-          // .add(offset, "hours")
-          // .add(timezone, "hours")
-          .format("HH:mm:ss")}
+    // changed all uses of moment to use date-fns
+    <ThemeProvider theme={theme}>      
+      <Typography variant="h4" component="h1" align="center">   
+        {currentTime}        
         {` ${parseTimezone(timezone)}`}
       </Typography>
       <Typography align="center">
-        {moment(currentDay, "e").format("dddd")}
+        {format(setDay(new Date(), currentDay), 'EEEE')}                     
       </Typography>
       <Box>
         <TimezoneControl timezone={timezone} useStore={useStore} />

--- a/src/Events.js
+++ b/src/Events.js
@@ -46,9 +46,7 @@ export default function Events(props) {
     days[moment(currentDay, "e").subtract(1, "days").format("e")]; // string "sat"
   const nextDay = days[moment(currentDay, "e").add(1, "days").format("e")]; // string "sat"
   const setCurrentTime = useStore((state) => state.setCurrentTime);
-  const setCurrentDay = useStore((state) => state.setCurrentDay);
-  const setCurrentDateTime = useStore((state) => state.setCurrentDateTime);
-  const setCurrentDateTimeFNS = useStore((state) => state.setCurrentDateTimeFNS);
+  const setCurrentDay = useStore((state) => state.setCurrentDay);  
   const eventCount = 30;
 
   const parseTimezone = (timezone) => {
@@ -203,6 +201,7 @@ export default function Events(props) {
       //setCurrentDay(moment().utc().add(timezone, "hours").format("e"));
       //new   
       setCurrentDay(formatInTimeZone(add(new Date(), { hours: timezone}),"UTC",  'i'));
+
       // Test Time
       // setCurrentTime(moment("6:19", "HH:mm").format("HH:mm:ss"));
       // setCurrentDay(moment("03-25-2022", "MM-DD-YYYY").format("e")); // friday
@@ -218,7 +217,7 @@ export default function Events(props) {
   const parsedEvents = parseEvents();
 
   return (
-    // changed all uses of moment to use date-fns
+    // changed uses of moment to use date-fns
     <ThemeProvider theme={theme}>      
       <Typography variant="h4" component="h1" align="center">   
         {currentTime}        


### PR DESCRIPTION
I removed the use of moment.js from App.js and used date-fns/date-fns-tz instead. I don't know a lot of js and react, but I believe I have recreated the functionality using date-fns libraries. Please confirm that I am setting the currentDay and currentTime event state variables appropriately.

Also started to implement date-fns use in Events.js, so far only top center time and day fields have been updated to use date-fns. I wanted to get conformation that I am doing things appropriately before working through Events.js since moment.js is used more widely there. Let me know if I'm on the right track! 